### PR TITLE
Add an inspect method on the table class

### DIFF
--- a/lib/algebra_db/table.rb
+++ b/lib/algebra_db/table.rb
@@ -11,6 +11,11 @@ module AlgebraDB
         (@columns || {}).dup
       end
 
+      def inspect
+        str = "#<#{self.name}:#{self.object_id} "
+        str << "columns=[#{self.columns.keys.map(&:inspect).join(", ")}]>"
+      end
+
       def column(name, value)
         value = ::AlgebraDB::Value.const_get(value) if value.is_a?(Symbol)
         @columns ||= {}


### PR DESCRIPTION
Not my finest work ever, but I think it's kinda useful. Feel free to scrap this if you want, I don't care much.
```
Connors-MacBook-Pro:algebra_db connorshea$ ./bin/console
[1] pry(main)> UserAudit.inspect
=> "#<UserAudit:70134809354640 columns=[:id, :user_id, :scopes_granted, :changes]>"
```

Ideally it'd also list the available relationships on the table and maybe show the types of the columns (I didn't do that here because it was way too much information and hard to format well).